### PR TITLE
fix: update prerelease constraint

### DIFF
--- a/nuxt/index.ts
+++ b/nuxt/index.ts
@@ -11,7 +11,7 @@ export default defineNuxtModule({
     name: 'zetto',
     configKey: 'zetto',
     compatibility: {
-      nuxt: '^3.0.0',
+      nuxt: '^3.0.0-rc.6',
     },
   },
   // Default configuration options for the module


### PR DESCRIPTION
In https://github.com/nuxt/framework/pull/7116 we made a breaking change allowing modules to use RC constraints. This PR fixes this.